### PR TITLE
Add ReepayCheckoutSheet v1.1.12

### DIFF
--- a/ReepayCheckoutExample/ReepayCheckoutExample.xcodeproj/project.pbxproj
+++ b/ReepayCheckoutExample/ReepayCheckoutExample.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.1.8;
+				CURRENT_PROJECT_VERSION = 1.1.12;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -381,7 +381,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.1.8;
+				CURRENT_PROJECT_VERSION = 1.1.12;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -412,7 +412,7 @@
 				CODE_SIGN_ENTITLEMENTS = ReepayCheckoutExample/ReepayCheckoutExample.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = 1.1.12;
 				DEVELOPMENT_ASSET_PATHS = "\"ReepayCheckoutExample/Preview Content\"";
 				DEVELOPMENT_TEAM = XGLU324D57;
 				ENABLE_PREVIEWS = YES;
@@ -429,7 +429,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reepay.ReepayCheckoutExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -451,7 +451,7 @@
 				CODE_SIGN_ENTITLEMENTS = ReepayCheckoutExample/ReepayCheckoutExample.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = 1.1.12;
 				DEVELOPMENT_ASSET_PATHS = "\"ReepayCheckoutExample/Preview Content\"";
 				DEVELOPMENT_TEAM = XGLU324D57;
 				ENABLE_PREVIEWS = YES;
@@ -468,7 +468,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reepay.ReepayCheckoutExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -516,7 +516,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.1.8;
+				CURRENT_PROJECT_VERSION = 1.1.12;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -554,7 +554,7 @@
 				CODE_SIGN_ENTITLEMENTS = ReepayCheckoutExample/ReepayCheckoutExample.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = 1.1.12;
 				DEVELOPMENT_ASSET_PATHS = "\"ReepayCheckoutExample/Preview Content\"";
 				DEVELOPMENT_TEAM = XGLU324D57;
 				ENABLE_PREVIEWS = YES;
@@ -571,7 +571,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reepay.ReepayCheckoutExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -619,7 +619,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.1.8;
+				CURRENT_PROJECT_VERSION = 1.1.12;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -650,7 +650,7 @@
 				CODE_SIGN_ENTITLEMENTS = ReepayCheckoutExample/ReepayCheckoutExample.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.0.0;
+				CURRENT_PROJECT_VERSION = 1.1.12;
 				DEVELOPMENT_ASSET_PATHS = "\"ReepayCheckoutExample/Preview Content\"";
 				DEVELOPMENT_TEAM = XGLU324D57;
 				ENABLE_PREVIEWS = YES;
@@ -667,7 +667,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.12;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reepay.ReepayCheckoutExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/ReepayCheckoutExample/ReepayCheckoutExample.xcodeproj/project.pbxproj
+++ b/ReepayCheckoutExample/ReepayCheckoutExample.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		B225B5B62BA89FC3009F3DDA /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B225B5B52BA89FC3009F3DDA /* SidebarView.swift */; };
 		B225B5B82BA8A002009F3DDA /* OldContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B225B5B72BA8A002009F3DDA /* OldContentView.swift */; };
 		B225B5BA2BA8A08D009F3DDA /* UIVIewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B225B5B92BA8A08D009F3DDA /* UIVIewControllerWrapper.swift */; };
+		B2C13CC82EA8F87A0038DC2A /* WKWebView+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C13CC52EA8F85A0038DC2A /* WKWebView+Extension.swift */; };
+		B2C13CCA2EA8F9260038DC2A /* MyWebView+Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C13CC92EA8F9190038DC2A /* MyWebView+Coordinator.swift */; };
 		B2D5665D2BA9DF3200B0DDFE /* MyCheckoutConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D5665C2BA9DF3200B0DDFE /* MyCheckoutConfiguration.swift */; };
 		B2D5666B2BAC78AE00B0DDFE /* CustomContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D5666A2BAC78AE00B0DDFE /* CustomContentView.swift */; };
 		B2D566702BAC9BF800B0DDFE /* SessionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2D5666F2BAC9BF800B0DDFE /* SessionModel.swift */; };
@@ -55,6 +57,8 @@
 		B263B3452D2D7DE2009674F1 /* MyWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyWebView.swift; sourceTree = "<group>"; };
 		B263B3482D2E89EE009674F1 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		B29C1F802C7C95C100435112 /* ReepayCheckoutExample.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = ReepayCheckoutExample.entitlements; sourceTree = "<group>"; };
+		B2C13CC52EA8F85A0038DC2A /* WKWebView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Extension.swift"; sourceTree = "<group>"; };
+		B2C13CC92EA8F9190038DC2A /* MyWebView+Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MyWebView+Coordinator.swift"; sourceTree = "<group>"; };
 		B2D5665C2BA9DF3200B0DDFE /* MyCheckoutConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyCheckoutConfiguration.swift; sourceTree = "<group>"; };
 		B2D5666A2BAC78AE00B0DDFE /* CustomContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomContentView.swift; sourceTree = "<group>"; };
 		B2D5666F2BAC9BF800B0DDFE /* SessionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionModel.swift; sourceTree = "<group>"; };
@@ -124,7 +128,9 @@
 			children = (
 				B263B3482D2E89EE009674F1 /* Constants.swift */,
 				B225B5B22BA89EC7009F3DDA /* Color+HEX.swift */,
+				B2C13CC92EA8F9190038DC2A /* MyWebView+Coordinator.swift */,
 				B225B5B92BA8A08D009F3DDA /* UIVIewControllerWrapper.swift */,
+				B2C13CC52EA8F85A0038DC2A /* WKWebView+Extension.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -265,7 +271,9 @@
 				B225B5A62BA89468009F3DDA /* NewContentView.swift in Sources */,
 				B2D5665D2BA9DF3200B0DDFE /* MyCheckoutConfiguration.swift in Sources */,
 				B225B5B82BA8A002009F3DDA /* OldContentView.swift in Sources */,
+				B2C13CCA2EA8F9260038DC2A /* MyWebView+Coordinator.swift in Sources */,
 				B225B5BA2BA8A08D009F3DDA /* UIVIewControllerWrapper.swift in Sources */,
+				B2C13CC82EA8F87A0038DC2A /* WKWebView+Extension.swift in Sources */,
 				B225B5A42BA89468009F3DDA /* ReepayCheckoutExampleApp.swift in Sources */,
 				B2DA782E2C355A2E00E354D5 /* AppDelegate.swift in Sources */,
 				B2D566702BAC9BF800B0DDFE /* SessionModel.swift in Sources */,

--- a/ReepayCheckoutExample/ReepayCheckoutExample/Helpers/MyWebView+Coordinator.swift
+++ b/ReepayCheckoutExample/ReepayCheckoutExample/Helpers/MyWebView+Coordinator.swift
@@ -1,0 +1,34 @@
+//
+//  MyWebView+Coordinator.swift
+//  ReepayCheckoutExample
+//
+//  Created by Johnny Ly on 22/10/2025.
+//
+
+import WebKit
+
+extension MyWebView.Coordinator {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url else {
+            decisionHandler(.cancel)
+            return
+        }
+
+        if UIApplication.shared.canOpenURL(url), url.scheme != "http",
+            url.scheme != "https"
+        {
+            UIApplication.shared.open(url)
+        }
+
+        if !shouldNavigate {
+            decisionHandler(.cancel)
+            return
+        }
+
+        decisionHandler(.allow)
+    }
+}

--- a/ReepayCheckoutExample/ReepayCheckoutExample/Helpers/MyWebView+Coordinator.swift
+++ b/ReepayCheckoutExample/ReepayCheckoutExample/Helpers/MyWebView+Coordinator.swift
@@ -13,6 +13,14 @@ extension MyWebView.Coordinator {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
+        // This is our own load if its URL matches. Clear it once matched so it can't
+        // wrongly match a later page redirect.
+        let isSDKInitiatedLoad = pendingProgrammaticURL != nil
+            && navigationAction.request.url == pendingProgrammaticURL
+        if isSDKInitiatedLoad {
+            pendingProgrammaticURL = nil
+        }
+
         guard let url = navigationAction.request.url else {
             decisionHandler(.cancel)
             return
@@ -24,7 +32,10 @@ extension MyWebView.Coordinator {
             UIApplication.shared.open(url)
         }
 
-        if !shouldNavigate {
+        // When navigation handling is off, block page redirects but always allow our
+        // own load and any redirect hops it triggers.
+        let belongsToSDKNavigation = isSDKInitiatedLoad || sdkInitiatedNavigation != nil
+        if !webView.shouldHandleNavigation, !belongsToSDKNavigation {
             decisionHandler(.cancel)
             return
         }

--- a/ReepayCheckoutExample/ReepayCheckoutExample/Helpers/WKWebView+Extension.swift
+++ b/ReepayCheckoutExample/ReepayCheckoutExample/Helpers/WKWebView+Extension.swift
@@ -1,0 +1,28 @@
+//
+//  WKWebView+Boolean.swift
+//  ReepayCheckoutExample
+//
+//  Created by Johnny Ly on 22/10/2025.
+//
+
+import ObjectiveC
+import WebKit
+
+private var shouldNavigateKey: UInt8 = 0
+
+extension WKWebView {
+    public var shouldNavigate: Bool {
+        get {
+            return objc_getAssociatedObject(self, &shouldNavigateKey)
+                as? Bool ?? true
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &shouldNavigateKey,
+                newValue,
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+}

--- a/ReepayCheckoutExample/ReepayCheckoutExample/Helpers/WKWebView+Extension.swift
+++ b/ReepayCheckoutExample/ReepayCheckoutExample/Helpers/WKWebView+Extension.swift
@@ -8,18 +8,18 @@
 import ObjectiveC
 import WebKit
 
-private var shouldNavigateKey: UInt8 = 0
+private var shouldHandleNavigationKey: UInt8 = 0
 
 extension WKWebView {
-    public var shouldNavigate: Bool {
+    public var shouldHandleNavigation: Bool {
         get {
-            return objc_getAssociatedObject(self, &shouldNavigateKey)
-                as? Bool ?? true
+            return (objc_getAssociatedObject(self, &shouldHandleNavigationKey)
+                as? NSNumber)?.boolValue ?? true
         }
         set {
             objc_setAssociatedObject(
                 self,
-                &shouldNavigateKey,
+                &shouldHandleNavigationKey,
                 newValue,
                 .OBJC_ASSOCIATION_RETAIN_NONATOMIC
             )

--- a/ReepayCheckoutExample/ReepayCheckoutExample/Views/MyWebView.swift
+++ b/ReepayCheckoutExample/ReepayCheckoutExample/Views/MyWebView.swift
@@ -16,7 +16,8 @@ struct MyWebView: UIViewRepresentable {
     class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, WKScriptMessageHandlerWithReply {
         weak var webView: WKWebView?
         var parent: MyWebView
-        
+        var shouldNavigate: Bool = true
+
         init(_ parent: MyWebView) {
             self.parent = parent
         }
@@ -74,7 +75,7 @@ struct MyWebView: UIViewRepresentable {
                 /// Let ReepayCheckout know a webview is being used and should send webview events to my app:
                 reply = [
                     "isWebView": true,
-                    "userAgent": "Unknown",
+                    "userAgent": "AppleWebKit",
                 ]
             case "card_input_change":
                 /// Let ReepayCheckout know webview has changed/touched by user and stop sending further "card_input_change" events:
@@ -110,6 +111,9 @@ struct MyWebView: UIViewRepresentable {
             case "Accept":
                 print("Payment completed with: \(response)")
                 parent.show = false
+                
+                /// Stop navigation after accept event to prevent webview from redirecting to accept URL:
+                // shouldNavigate = false
             case "Cancel":
                 print("Payment cancelled with: \(response)")
                 parent.show = false

--- a/ReepayCheckoutExample/ReepayCheckoutExample/Views/MyWebView.swift
+++ b/ReepayCheckoutExample/ReepayCheckoutExample/Views/MyWebView.swift
@@ -16,14 +16,34 @@ struct MyWebView: UIViewRepresentable {
     class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler, WKScriptMessageHandlerWithReply {
         weak var webView: WKWebView?
         var parent: MyWebView
-        var shouldNavigate: Bool = true
+
+        /// URL of the load we started ourselves, so we don't cancel it when navigation handling is off.
+        var pendingProgrammaticURL: URL?
+
+        /// Our current load. Stays set until it finishes/fails so its redirect hops are allowed too.
+        var sdkInitiatedNavigation: WKNavigation?
 
         init(_ parent: MyWebView) {
             self.parent = parent
         }
 
+        /// Load a request while tracking it as our own, mirroring the SDK's `loadInternally`.
+        @discardableResult
+        func loadInternally(_ request: URLRequest, in webView: WKWebView) -> WKNavigation? {
+            pendingProgrammaticURL = request.url
+            let navigation = webView.load(request)
+            sdkInitiatedNavigation = navigation
+            return navigation
+        }
+
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             print("WebView finished loading")
+
+            // Clear our load state so it doesn't carry over to later page navigations.
+            pendingProgrammaticURL = nil
+            if navigation == sdkInitiatedNavigation {
+                sdkInitiatedNavigation = nil
+            }
         }
 
         // Handle WKScriptMessageHandlerWithReply (iOS 17+)
@@ -113,7 +133,7 @@ struct MyWebView: UIViewRepresentable {
                 parent.show = false
                 
                 /// Stop navigation after accept event to prevent webview from redirecting to accept URL:
-                // shouldNavigate = false
+                // webView?.shouldHandleNavigation = false
             case "Cancel":
                 print("Payment cancelled with: \(response)")
                 parent.show = false
@@ -151,6 +171,6 @@ struct MyWebView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
-        uiView.load(URLRequest(url: url))
+        context.coordinator.loadInternally(URLRequest(url: url), in: uiView)
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes WKWebView navigation policy and external URL handling in the payment webview example, which can affect checkout completion and redirects if enabled incorrectly.
> 
> **Overview**
> Bumps the **ReepayCheckoutExample** app to **1.1.12** and updates the custom **MyWebView** checkout path to align with ReepayCheckoutSheet-style web navigation control.
> 
> **MyWebView** now loads checkout URLs via tracked **`loadInternally`** (pending URL + navigation object) and clears that state on **`didFinish`**, so redirect hops from the initial load stay allowed while unrelated navigations can be blocked. A **`WKWebView.shouldHandleNavigation`** associated flag (default **true**) gates whether in-web navigations are allowed; **`decidePolicyFor`** cancels page redirects when handling is off unless the request belongs to the SDK-initiated load. Non-**http/https** schemes are handed off to **`UIApplication.shared.open`**.
> 
> The Init bridge reply’s **`userAgent`** changes from **`Unknown`** to **`AppleWebKit`**. A commented hook on **Accept** would set **`shouldHandleNavigation = false`** to avoid post-payment accept URL redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e8114682024aba3b399e4fadcad2ffdbfd1df31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->